### PR TITLE
Fix quickjs fuzzer determinism

### DIFF
--- a/fuzzers/quickjs/Cargo.lock
+++ b/fuzzers/quickjs/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -321,18 +321,18 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9742810f4cb95388955853c032cd50415d18834357f67b7b299fc28217cd3d"
+checksum = "a78c049190826fff959994b7c1d8a2930d0a348f1b8f3aa4f9bb34cd5d7f2952"
 dependencies = [
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.6.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b8002ac5e13e1f61da5b8c440fe4de5bae029b4538cd899ef2dd93e1245bf71"
+checksum = "97422ba48d7ffb66fd4d18130f72ab66f9bbbf791fb7a87b9291cdcfec437593"
 dependencies = [
  "kvm-bindings",
  "libc",
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libm"
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "itoa",
  "ryu",
@@ -740,9 +740,10 @@ version = "0.1.0"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
- "nix 0.20.0",
+ "nix 0.23.0",
  "serde",
  "serde_json",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -836,9 +837,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cdd1d72e262bbfb014de65ada24c1ac50e10a2e3b1e8ec052df188c2ee5dfa"
+checksum = "733537bded03aaa93543f785ae997727b30d1d9f4a03b7861d23290474242e11"
 dependencies = [
  "bitflags",
  "libc",

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -10,8 +10,9 @@ keywords = ["kvm", "emulation"]
 description= "Unicorn like wrappers around kvm"
 
 [dependencies]
-kvm-ioctls = "0.6.1"
-kvm-bindings = "0.3.1"
-nix = "0.20.0"
+kvm-ioctls = "0.11.0"
+kvm-bindings = "0.5.0"
+nix = "0.23.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+vmm-sys-util = "0.9.0"

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -6,6 +6,9 @@ mod snapshot;
 mod vm;
 mod x64;
 
+#[macro_use]
+extern crate vmm_sys_util;
+
 pub use memory::{Mapping, PagePermissions};
 pub use snapshot::{
     SnapshotError, SnapshotInfo, SnapshotMapping, SnapshotModule, SnapshotRegisters,

--- a/vm/src/memory/paging.rs
+++ b/vm/src/memory/paging.rs
@@ -262,10 +262,22 @@ impl PageTableEntry {
         self.0.is_bit_set(Self::WRITE_CACHING_BIT)
     }
 
+    /// Set whether or not the write go directly to memory on this page
+    #[inline]
+    pub fn set_write_caching(&mut self, write_caching: bool) {
+        self.0.set_bit(Self::WRITE_CACHING_BIT, write_caching);
+    }
+
     /// Whether or not the cache is enable for this page
     #[inline]
     pub fn caching(&self) -> bool {
         !self.0.is_bit_set(Self::CACHE_DISABLE_BIT)
+    }
+
+    /// Set Whether or not the cache is enable for this page
+    #[inline]
+    pub fn set_caching(&mut self, caching: bool) {
+        self.0.set_bit(Self::CACHE_DISABLE_BIT, !caching)
     }
 
     /// Whether or not the page was accessed by the CPU

--- a/vm/src/memory/virt.rs
+++ b/vm/src/memory/virt.rs
@@ -217,8 +217,8 @@ impl VirtualMemory {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
 /// Memory mapping inside the VirtualMemory
+#[derive(Debug, Copy, Clone)]
 pub struct Mapping {
     /// Address of the mapping
     pub address: u64,


### PR DESCRIPTION
Tartiflette-vm:
- Add set_write_caching and set_caching utils for pagination
- Use manual manipulation of dirty log for cleaning
- Add documentations
- Sync kvm run structure when flushing
- Update to latests crates version

Quickjs Fuzzer:
- Null terminate input passed to quickjs
- Add checks to not overfeed the BufWriter
- Add debug exception handling (occur after a singlestep)
- Add INT3 definition
- Add Madvise syscall handling
- Add comments
- Format

Quickjs corpus generator:
- Add comments
- Add directories creation if not existing